### PR TITLE
Add functionality to return selectors with specificity score in order

### DIFF
--- a/lib/get-specificity-values.js
+++ b/lib/get-specificity-values.js
@@ -1,0 +1,16 @@
+var _ = require('lodash')
+
+module.exports = function (selectors, graph) {
+  selectors = selectors || this.values
+  graph = graph || this.getSpecificityGraph()
+
+  return _.zipWith(
+    selectors,
+    graph,
+    function (a, b) {
+      return {
+        selector: a,
+        specificity: b
+      }
+    })
+}

--- a/lib/selectors.js
+++ b/lib/selectors.js
@@ -6,6 +6,7 @@ var hasPseudoClass = require('has-pseudo-class')
 var hasElementSelector = require('has-element-selector')
 var getSpecificityGraph = require('./get-specificity-graph')
 var getRepeatedValues = require('./get-repeated-values')
+var getSpecificityValues = require('./get-specificity-values')
 var getSortedSpecificity = require('./get-sorted-specificity')
 
 module.exports = function (root, opts) {
@@ -22,6 +23,7 @@ module.exports = function (root, opts) {
       average: 0
     },
     getSpecificityGraph: getSpecificityGraph,
+    getSpecificityValues: getSpecificityValues,
     getSortedSpecificity: getSortedSpecificity,
     getRepeatedValues: getRepeatedValues
   }

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ The following options add the results of helper methods to the returned object. 
       average: n
     },
     getSpecificityGraph(),
+    getSpecificityValues(),
     getRepeatedValues(),
     getSortedSpecificity()
   },
@@ -177,6 +178,7 @@ The size of the stylesheet gzipped in bytes
   - `specificity.max` number - maximum specificity as a base 10 number
   - `specificity.average` number - average specificity as a base 10 number
 - `getSpecificityGraph()` function - returns an array of numbers for each selector’s specificity as a base 10 number
+- `getSpecificityValues()` function - returns an array of selectors with base 10 specificity score in order
 - `getRepeatedValues()` function - returns an array of strings of repeated selectors
 - `getSortedSpecificity()` function - returns an array of selectors with base 10 specificity score, sorted from highest to lowest
 

--- a/test/test.js
+++ b/test/test.js
@@ -128,6 +128,10 @@ describe('css-statistics', function () {
       assert.equal(stats.selectors.getSpecificityGraph().length > 0, true)
     })
 
+    it('should return specificity values for each selector in order', function () {
+      assert.deepEqual(stats.selectors.getSpecificityValues(), [ { selector: '.red', specificity: 10 }, { selector: '#foo', specificity: 100 }, { selector: '.red', specificity: 10 }, { selector: '.sm-tomato', specificity: 10 }, { selector: '.sm-tomato::after', specificity: 11 }, { selector: '.sm-tomato:first-child:last-child', specificity: 30 }, { selector: '.box', specificity: 10 }, { selector: '.box:first-child', specificity: 20 }, { selector: '.box:last-child', specificity: 20 }, { selector: '0%', specificity: 1 }, { selector: '100%', specificity: 1 }, { selector: 'header', specificity: 1 }, { selector: '.georgia', specificity: 10 } ])
+    })
+
     it('should return a sorted specificity array', function () {
       assert.deepEqual(stats.selectors.getSortedSpecificity(), [ { selector: '#foo', specificity: 100 }, { selector: '.sm-tomato:first-child:last-child', specificity: 30 }, { selector: '.box:first-child', specificity: 20 }, { selector: '.box:last-child', specificity: 20 }, { selector: '.sm-tomato::after', specificity: 11 }, { selector: '.box', specificity: 10 }, { selector: '.sm-tomato', specificity: 10 }, { selector: '.red', specificity: 10 }, { selector: '.red', specificity: 10 }, { selector: '.georgia', specificity: 10 }, { selector: '0%', specificity: 1 }, { selector: '100%', specificity: 1 }, { selector: 'header', specificity: 1 } ])
     })


### PR DESCRIPTION
This functionality helps to debug where rogue overly specific selectors are in the codebase