### PR TITLE
feature: return selectorByRuleSizes array in stats.rules result

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -7,11 +7,14 @@ module.exports = function (root, opts) {
       graph: [],
       max: 0,
       average: 0
-    }
+    },
+    selectorByRuleSizes: []
   }
 
   root.walkRules(function (rule) {
+    var selector = rule.selector
     var declarations = 0
+
     rule.nodes.forEach(function (node) {
       if (node.type === 'decl') {
         declarations++
@@ -20,7 +23,13 @@ module.exports = function (root, opts) {
 
     result.total++
     result.size.graph.push(declarations)
+    result.selectorByRuleSizes.push({
+      selector: selector,
+      declarations: declarations
+    })
   })
+
+  result.selectorByRuleSizes = _.sortBy(result.selectorByRuleSizes, 'declarations').reverse()
 
   if (result.total > 0) {
     result.size.max = _.max(result.size.graph)

--- a/test/results/basscss.json
+++ b/test/results/basscss.json
@@ -299,7 +299,1165 @@
       ],
       "max": 12,
       "average": 1.6297577854671281
-    }
+    },
+    "selectorByRuleSizes": [
+      {
+        "selector": "button,\n.button",
+        "declarations": 12
+      },
+      {
+        "selector": ".button-blue-outline",
+        "declarations": 11
+      },
+      {
+        "selector": ".button-red",
+        "declarations": 9
+      },
+      {
+        "selector": ".button-gray",
+        "declarations": 9
+      },
+      {
+        "selector": ".button-blue",
+        "declarations": 9
+      },
+      {
+        "selector": ".field-light",
+        "declarations": 7
+      },
+      {
+        "selector": ".absolute-center",
+        "declarations": 6
+      },
+      {
+        "selector": ".button-nav-tab.is-active",
+        "declarations": 5
+      },
+      {
+        "selector": ".hide",
+        "declarations": 5
+      },
+      {
+        "selector": "input[type=text],\ninput[type=datetime],\ninput[type=datetime-local],\ninput[type=email],\ninput[type=month],\ninput[type=number],\ninput[type=password],\ninput[type=search],\ninput[type=tel],\ninput[type=time],\ninput[type=url],\ninput[type=week]",
+        "declarations": 5
+      },
+      {
+        "selector": "blockquote",
+        "declarations": 5
+      },
+      {
+        "selector": "h1,\nh2,\nh3,\nh4,\nh5,\nh6",
+        "declarations": 5
+      },
+      {
+        "selector": ".field-dark",
+        "declarations": 4
+      },
+      {
+        "selector": "hr",
+        "declarations": 4
+      },
+      {
+        "selector": "table",
+        "declarations": 4
+      },
+      {
+        "selector": ".fieldset-reset",
+        "declarations": 4
+      },
+      {
+        "selector": "textarea",
+        "declarations": 4
+      },
+      {
+        "selector": "select",
+        "declarations": 4
+      },
+      {
+        "selector": ".border-left",
+        "declarations": 3
+      },
+      {
+        "selector": ".border-bottom",
+        "declarations": 3
+      },
+      {
+        "selector": ".border-right",
+        "declarations": 3
+      },
+      {
+        "selector": ".border-top",
+        "declarations": 3
+      },
+      {
+        "selector": ".border",
+        "declarations": 3
+      },
+      {
+        "selector": ".button-nav-tab",
+        "declarations": 3
+      },
+      {
+        "selector": ".button-blue-outline:disabled,\n.button-blue-outline.is-disabled",
+        "declarations": 3
+      },
+      {
+        "selector": ".table-light th,\n.table-light td",
+        "declarations": 3
+      },
+      {
+        "selector": ".field-light:focus",
+        "declarations": 3
+      },
+      {
+        "selector": ".lg-col-right",
+        "declarations": 3
+      },
+      {
+        "selector": ".lg-col",
+        "declarations": 3
+      },
+      {
+        "selector": ".md-col-right",
+        "declarations": 3
+      },
+      {
+        "selector": ".md-col",
+        "declarations": 3
+      },
+      {
+        "selector": ".sm-col-right",
+        "declarations": 3
+      },
+      {
+        "selector": ".sm-col",
+        "declarations": 3
+      },
+      {
+        "selector": ".col-right",
+        "declarations": 3
+      },
+      {
+        "selector": ".col",
+        "declarations": 3
+      },
+      {
+        "selector": ".container",
+        "declarations": 3
+      },
+      {
+        "selector": "pre",
+        "declarations": 3
+      },
+      {
+        "selector": "p,\ndl,\nol,\nul",
+        "declarations": 3
+      },
+      {
+        "selector": "body",
+        "declarations": 3
+      },
+      {
+        "selector": ".button-red:focus",
+        "declarations": 2
+      },
+      {
+        "selector": ".button-gray:focus",
+        "declarations": 2
+      },
+      {
+        "selector": ".button-blue-outline:focus",
+        "declarations": 2
+      },
+      {
+        "selector": ".button-blue-outline:hover,\n.button-blue-outline.is-active",
+        "declarations": 2
+      },
+      {
+        "selector": ".button-blue:focus",
+        "declarations": 2
+      },
+      {
+        "selector": ".field-dark:focus",
+        "declarations": 2
+      },
+      {
+        "selector": ".radio-light:focus,\n.checkbox-light:focus",
+        "declarations": 2
+      },
+      {
+        "selector": ".radio-light,\n.checkbox-light",
+        "declarations": 2
+      },
+      {
+        "selector": ".field-light:disabled",
+        "declarations": 2
+      },
+      {
+        "selector": "pre,\ncode",
+        "declarations": 2
+      },
+      {
+        "selector": "a",
+        "declarations": 2
+      },
+      {
+        "selector": "body",
+        "declarations": 2
+      },
+      {
+        "selector": ".lg-table-cell",
+        "declarations": 2
+      },
+      {
+        "selector": ".lg-table",
+        "declarations": 2
+      },
+      {
+        "selector": ".md-table-cell",
+        "declarations": 2
+      },
+      {
+        "selector": ".md-table",
+        "declarations": 2
+      },
+      {
+        "selector": ".sm-table-cell",
+        "declarations": 2
+      },
+      {
+        "selector": ".sm-table",
+        "declarations": 2
+      },
+      {
+        "selector": ".table-cell",
+        "declarations": 2
+      },
+      {
+        "selector": ".table",
+        "declarations": 2
+      },
+      {
+        "selector": ".x-group-item:focus,\n.x-group-item-2:focus,\n.y-group-item:focus,\n.y-group-item-2:focus",
+        "declarations": 2
+      },
+      {
+        "selector": ".button-narrow",
+        "declarations": 2
+      },
+      {
+        "selector": ".px4",
+        "declarations": 2
+      },
+      {
+        "selector": ".py4",
+        "declarations": 2
+      },
+      {
+        "selector": ".px3",
+        "declarations": 2
+      },
+      {
+        "selector": ".py3",
+        "declarations": 2
+      },
+      {
+        "selector": ".px2",
+        "declarations": 2
+      },
+      {
+        "selector": ".py2",
+        "declarations": 2
+      },
+      {
+        "selector": ".px1",
+        "declarations": 2
+      },
+      {
+        "selector": ".py1",
+        "declarations": 2
+      },
+      {
+        "selector": ".mx-auto",
+        "declarations": 2
+      },
+      {
+        "selector": ".mxn4",
+        "declarations": 2
+      },
+      {
+        "selector": ".mxn3",
+        "declarations": 2
+      },
+      {
+        "selector": ".mxn2",
+        "declarations": 2
+      },
+      {
+        "selector": ".mxn1",
+        "declarations": 2
+      },
+      {
+        "selector": ".caps",
+        "declarations": 2
+      },
+      {
+        "selector": ".clearfix:before,\n.clearfix:after",
+        "declarations": 2
+      },
+      {
+        "selector": "th,\ntd",
+        "declarations": 2
+      },
+      {
+        "selector": "th",
+        "declarations": 2
+      },
+      {
+        "selector": "::-moz-focus-inner",
+        "declarations": 2
+      },
+      {
+        "selector": "input,\nselect,\ntextarea,\nfieldset",
+        "declarations": 2
+      },
+      {
+        "selector": ".list-reset",
+        "declarations": 2
+      },
+      {
+        "selector": "blockquote,\nblockquote p",
+        "declarations": 2
+      },
+      {
+        "selector": "hr",
+        "declarations": 2
+      },
+      {
+        "selector": "pre,\ncode,\nsamp",
+        "declarations": 2
+      },
+      {
+        "selector": "button,\ninput,\nselect,\ntextarea",
+        "declarations": 2
+      },
+      {
+        "selector": ".not-rounded",
+        "declarations": 1
+      },
+      {
+        "selector": ".rounded-left",
+        "declarations": 1
+      },
+      {
+        "selector": ".rounded-bottom",
+        "declarations": 1
+      },
+      {
+        "selector": ".rounded-right",
+        "declarations": 1
+      },
+      {
+        "selector": ".rounded-top",
+        "declarations": 1
+      },
+      {
+        "selector": ".circle",
+        "declarations": 1
+      },
+      {
+        "selector": ".rounded",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-darken-4",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-darken-3",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-darken-2",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-darken-1",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-yellow",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-green",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-red",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-lighter-gray",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-light-gray",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-mid-gray",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-blue",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-white",
+        "declarations": 1
+      },
+      {
+        "selector": ".bg-dark-gray",
+        "declarations": 1
+      },
+      {
+        "selector": ".yellow",
+        "declarations": 1
+      },
+      {
+        "selector": ".green",
+        "declarations": 1
+      },
+      {
+        "selector": ".red",
+        "declarations": 1
+      },
+      {
+        "selector": ".lighter-gray",
+        "declarations": 1
+      },
+      {
+        "selector": ".light-gray",
+        "declarations": 1
+      },
+      {
+        "selector": ".mid-gray",
+        "declarations": 1
+      },
+      {
+        "selector": ".blue",
+        "declarations": 1
+      },
+      {
+        "selector": ".white",
+        "declarations": 1
+      },
+      {
+        "selector": ".dark-gray",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-nav-tab:hover",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-nav-dark:active,\n.button-nav-dark.is-active",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-nav-dark:hover",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-nav-dark",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-nav-light:active,\n.button-nav-light.is-active",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-nav-light:hover",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-red:disabled,\n.button-red.is-disabled",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-red:active,\n.button-red.is-active",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-red:hover",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-gray:disabled,\n.button-gray.is-disabled",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-gray:active,\n.button-gray:is-active",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-gray:hover",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-blue-outline:active",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-blue:disabled,\n.button-blue.is-disabled",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-blue:active,\n.button-blue.is-active",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-blue:hover",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark.is-error",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark.is-warning",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark.is-success",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark:invalid",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark:read-only:not(select)",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark::placeholder",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark:-ms-input-placeholder",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark::-moz-placeholder",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-dark::-webkit-input-placeholder",
+        "declarations": 1
+      },
+      {
+        "selector": ".radio-light",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-light.is-error",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-light.is-warning",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-light.is-success",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-light:invalid",
+        "declarations": 1
+      },
+      {
+        "selector": ".field-light:read-only:not(select)",
+        "declarations": 1
+      },
+      {
+        "selector": "a:hover",
+        "declarations": 1
+      },
+      {
+        "selector": ".table-fixed",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-12",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-11",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-10",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-9",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-8",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-7",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-6",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-5",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-4",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-3",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-2",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-col-1",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-12",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-11",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-10",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-9",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-8",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-7",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-6",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-5",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-4",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-3",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-2",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-col-1",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-12",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-11",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-10",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-9",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-8",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-7",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-6",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-5",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-4",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-3",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-2",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-col-1",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-12",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-11",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-10",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-9",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-8",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-7",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-6",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-5",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-4",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-3",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-2",
+        "declarations": 1
+      },
+      {
+        "selector": ".col-1",
+        "declarations": 1
+      },
+      {
+        "selector": ".disclosure-group.is-active .disclosure-show",
+        "declarations": 1
+      },
+      {
+        "selector": ".disclosure-group .disclosure-show",
+        "declarations": 1
+      },
+      {
+        "selector": ".y-group-item-2:first-of-type",
+        "declarations": 1
+      },
+      {
+        "selector": ".y-group-item-2",
+        "declarations": 1
+      },
+      {
+        "selector": ".x-group-item-2:first-of-type",
+        "declarations": 1
+      },
+      {
+        "selector": ".x-group-item-2",
+        "declarations": 1
+      },
+      {
+        "selector": ".y-group-item:first-of-type",
+        "declarations": 1
+      },
+      {
+        "selector": ".y-group-item",
+        "declarations": 1
+      },
+      {
+        "selector": ".x-group-item:first-of-type",
+        "declarations": 1
+      },
+      {
+        "selector": ".x-group-item",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-big",
+        "declarations": 1
+      },
+      {
+        "selector": ".button-small",
+        "declarations": 1
+      },
+      {
+        "selector": ".z4",
+        "declarations": 1
+      },
+      {
+        "selector": ".z3",
+        "declarations": 1
+      },
+      {
+        "selector": ".z2",
+        "declarations": 1
+      },
+      {
+        "selector": ".z1",
+        "declarations": 1
+      },
+      {
+        "selector": ".left-0",
+        "declarations": 1
+      },
+      {
+        "selector": ".bottom-0",
+        "declarations": 1
+      },
+      {
+        "selector": ".right-0",
+        "declarations": 1
+      },
+      {
+        "selector": ".top-0",
+        "declarations": 1
+      },
+      {
+        "selector": ".fixed",
+        "declarations": 1
+      },
+      {
+        "selector": ".absolute",
+        "declarations": 1
+      },
+      {
+        "selector": ".relative",
+        "declarations": 1
+      },
+      {
+        "selector": ".display-none",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-hide",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-hide",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-hide",
+        "declarations": 1
+      },
+      {
+        "selector": ".lg-show",
+        "declarations": 1
+      },
+      {
+        "selector": ".md-show",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-show",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-show,\n.md-show,\n.lg-show",
+        "declarations": 1
+      },
+      {
+        "selector": ".p4",
+        "declarations": 1
+      },
+      {
+        "selector": ".p3",
+        "declarations": 1
+      },
+      {
+        "selector": ".p2",
+        "declarations": 1
+      },
+      {
+        "selector": ".p1",
+        "declarations": 1
+      },
+      {
+        "selector": ".ml4",
+        "declarations": 1
+      },
+      {
+        "selector": ".mb4",
+        "declarations": 1
+      },
+      {
+        "selector": ".mr4",
+        "declarations": 1
+      },
+      {
+        "selector": ".mt4",
+        "declarations": 1
+      },
+      {
+        "selector": ".m4",
+        "declarations": 1
+      },
+      {
+        "selector": ".ml3",
+        "declarations": 1
+      },
+      {
+        "selector": ".mb3",
+        "declarations": 1
+      },
+      {
+        "selector": ".mr3",
+        "declarations": 1
+      },
+      {
+        "selector": ".mt3",
+        "declarations": 1
+      },
+      {
+        "selector": ".m3",
+        "declarations": 1
+      },
+      {
+        "selector": ".ml2",
+        "declarations": 1
+      },
+      {
+        "selector": ".mb2",
+        "declarations": 1
+      },
+      {
+        "selector": ".mr2",
+        "declarations": 1
+      },
+      {
+        "selector": ".mt2",
+        "declarations": 1
+      },
+      {
+        "selector": ".m2",
+        "declarations": 1
+      },
+      {
+        "selector": ".ml1",
+        "declarations": 1
+      },
+      {
+        "selector": ".mb1",
+        "declarations": 1
+      },
+      {
+        "selector": ".mr1",
+        "declarations": 1
+      },
+      {
+        "selector": ".mt1",
+        "declarations": 1
+      },
+      {
+        "selector": ".m1",
+        "declarations": 1
+      },
+      {
+        "selector": ".ml0",
+        "declarations": 1
+      },
+      {
+        "selector": ".mb0",
+        "declarations": 1
+      },
+      {
+        "selector": ".mr0",
+        "declarations": 1
+      },
+      {
+        "selector": ".mt0",
+        "declarations": 1
+      },
+      {
+        "selector": ".m0",
+        "declarations": 1
+      },
+      {
+        "selector": ".nowrap",
+        "declarations": 1
+      },
+      {
+        "selector": ".justify",
+        "declarations": 1
+      },
+      {
+        "selector": ".right-align",
+        "declarations": 1
+      },
+      {
+        "selector": ".center",
+        "declarations": 1
+      },
+      {
+        "selector": ".left-align",
+        "declarations": 1
+      },
+      {
+        "selector": ".italic",
+        "declarations": 1
+      },
+      {
+        "selector": ".regular",
+        "declarations": 1
+      },
+      {
+        "selector": ".bold",
+        "declarations": 1
+      },
+      {
+        "selector": ".full-width",
+        "declarations": 1
+      },
+      {
+        "selector": ".half-width",
+        "declarations": 1
+      },
+      {
+        "selector": ".fit",
+        "declarations": 1
+      },
+      {
+        "selector": ".right",
+        "declarations": 1
+      },
+      {
+        "selector": ".left",
+        "declarations": 1
+      },
+      {
+        "selector": ".clearfix:after",
+        "declarations": 1
+      },
+      {
+        "selector": ".overflow-scroll",
+        "declarations": 1
+      },
+      {
+        "selector": ".overflow-hidden",
+        "declarations": 1
+      },
+      {
+        "selector": ".inline-block",
+        "declarations": 1
+      },
+      {
+        "selector": ".block",
+        "declarations": 1
+      },
+      {
+        "selector": ".inline",
+        "declarations": 1
+      },
+      {
+        "selector": "td",
+        "declarations": 1
+      },
+      {
+        "selector": "th",
+        "declarations": 1
+      },
+      {
+        "selector": ".button:hover",
+        "declarations": 1
+      },
+      {
+        "selector": ".fieldset-reset legend",
+        "declarations": 1
+      },
+      {
+        "selector": "select:not([multiple])",
+        "declarations": 1
+      },
+      {
+        "selector": "h6,\n.h6",
+        "declarations": 1
+      },
+      {
+        "selector": "h5,\n.h5",
+        "declarations": 1
+      },
+      {
+        "selector": "h4,\n.h4",
+        "declarations": 1
+      },
+      {
+        "selector": "h3,\n.h3",
+        "declarations": 1
+      },
+      {
+        "selector": "h2,\n.h2",
+        "declarations": 1
+      },
+      {
+        "selector": "h1,\n.h1",
+        "declarations": 1
+      },
+      {
+        "selector": "ol,\nul",
+        "declarations": 1
+      },
+      {
+        "selector": "svg",
+        "declarations": 1
+      },
+      {
+        "selector": "img",
+        "declarations": 1
+      },
+      {
+        "selector": "body,\nbutton",
+        "declarations": 1
+      }
+    ]
   },
   "selectors": {
     "total": 347,
@@ -1327,7 +2485,13 @@
             ],
             "max": 1,
             "average": 1
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ".sm-show",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 1,
@@ -1364,7 +2528,13 @@
             ],
             "max": 1,
             "average": 1
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ".md-show",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 1,
@@ -1401,7 +2571,13 @@
             ],
             "max": 1,
             "average": 1
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ".lg-show",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 1,
@@ -1438,7 +2614,13 @@
             ],
             "max": 1,
             "average": 1
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ".sm-hide",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 1,
@@ -1475,7 +2657,13 @@
             ],
             "max": 1,
             "average": 1
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ".md-hide",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 1,
@@ -1512,7 +2700,13 @@
             ],
             "max": 1,
             "average": 1
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ".lg-hide",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 1,
@@ -1562,7 +2756,65 @@
             ],
             "max": 3,
             "average": 1.2857142857142858
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ",.sm-col-right",
+              "declarations": 3
+            },
+            {
+              "selector": ".sm-col",
+              "declarations": 3
+            },
+            {
+              "selector": ",.sm-col-12",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-11",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-10",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-9",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-8",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-7",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-6",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-5",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-4",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-3",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-2",
+              "declarations": 1
+            },
+            {
+              "selector": ",.sm-col-1",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 14,
@@ -1648,7 +2900,65 @@
             ],
             "max": 3,
             "average": 1.2857142857142858
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ",.md-col-right",
+              "declarations": 3
+            },
+            {
+              "selector": ".md-col",
+              "declarations": 3
+            },
+            {
+              "selector": ",.md-col-12",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-11",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-10",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-9",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-8",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-7",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-6",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-5",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-4",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-3",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-2",
+              "declarations": 1
+            },
+            {
+              "selector": ",.md-col-1",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 14,
@@ -1734,7 +3044,65 @@
             ],
             "max": 3,
             "average": 1.2857142857142858
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ",.lg-col-right",
+              "declarations": 3
+            },
+            {
+              "selector": ".lg-col",
+              "declarations": 3
+            },
+            {
+              "selector": ",.lg-col-12",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-11",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-10",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-9",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-8",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-7",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-6",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-5",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-4",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-3",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-2",
+              "declarations": 1
+            },
+            {
+              "selector": ",.lg-col-1",
+              "declarations": 1
+            }
+          ]
         },
         "selectors": {
           "total": 14,
@@ -1808,7 +3176,17 @@
             ],
             "max": 2,
             "average": 2
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ",.sm-table-cell",
+              "declarations": 2
+            },
+            {
+              "selector": ".sm-table",
+              "declarations": 2
+            }
+          ]
         },
         "selectors": {
           "total": 2,
@@ -1854,7 +3232,17 @@
             ],
             "max": 2,
             "average": 2
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ",.md-table-cell",
+              "declarations": 2
+            },
+            {
+              "selector": ".md-table",
+              "declarations": 2
+            }
+          ]
         },
         "selectors": {
           "total": 2,
@@ -1900,7 +3288,17 @@
             ],
             "max": 2,
             "average": 2
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ",.lg-table-cell",
+              "declarations": 2
+            },
+            {
+              "selector": ".lg-table",
+              "declarations": 2
+            }
+          ]
         },
         "selectors": {
           "total": 2,

--- a/test/results/font-awesome.json
+++ b/test/results/font-awesome.json
@@ -521,7 +521,2053 @@
       ],
       "max": 6,
       "average": 1.086105675146771
-    }
+    },
+    "selectorByRuleSizes": [
+      {
+        "selector": ".fa-stack",
+        "declarations": 6
+      },
+      {
+        "selector": ".fa",
+        "declarations": 6
+      },
+      {
+        "selector": ".fa-li",
+        "declarations": 5
+      },
+      {
+        "selector": ".fa-stack-1x,.fa-stack-2x",
+        "declarations": 4
+      },
+      {
+        "selector": ".fa-flip-vertical",
+        "declarations": 4
+      },
+      {
+        "selector": ".fa-flip-horizontal",
+        "declarations": 4
+      },
+      {
+        "selector": ".fa-rotate-270",
+        "declarations": 4
+      },
+      {
+        "selector": ".fa-rotate-180",
+        "declarations": 4
+      },
+      {
+        "selector": ".fa-rotate-90",
+        "declarations": 4
+      },
+      {
+        "selector": ".fa-border",
+        "declarations": 3
+      },
+      {
+        "selector": ".fa-ul",
+        "declarations": 3
+      },
+      {
+        "selector": ".fa-lg",
+        "declarations": 3
+      },
+      {
+        "selector": "100%",
+        "declarations": 2
+      },
+      {
+        "selector": "0%",
+        "declarations": 2
+      },
+      {
+        "selector": "100%",
+        "declarations": 2
+      },
+      {
+        "selector": "0%",
+        "declarations": 2
+      },
+      {
+        "selector": ".fa-spin",
+        "declarations": 2
+      },
+      {
+        "selector": ".fa-fw",
+        "declarations": 2
+      },
+      {
+        "selector": ".fa-meanpath:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-shekel:before,.fa-sheqel:before,.fa-ils:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angellist:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ioxhost:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bus:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bicycle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-toggle-on:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-toggle-off:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-lastfm-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-lastfm:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-line-chart:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pie-chart:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-area-chart:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-birthday-cake:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-paint-brush:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-eyedropper:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-at:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-copyright:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-trash:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bell-slash-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bell-slash:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cc-stripe:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cc-paypal:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cc-amex:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cc-discover:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cc-mastercard:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cc-visa:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-google-wallet:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-paypal:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-calculator:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-wifi:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-newspaper-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-yelp:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-twitch:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-slideshare:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-plug:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-binoculars:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tty:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-soccer-ball-o:before,.fa-futbol-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bomb:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-share-alt-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-share-alt:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sliders:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-paragraph:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-header:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-circle-thin:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-history:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-send-o:before,.fa-paper-plane-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-send:before,.fa-paper-plane:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-wechat:before,.fa-weixin:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-qq:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tencent-weibo:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-hacker-news:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-git:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-git-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ge:before,.fa-empire:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ra:before,.fa-rebel:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-circle-o-notch:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-life-bouy:before,.fa-life-buoy:before,.fa-life-saver:before,.fa-support:before,.fa-life-ring:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-jsfiddle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-codepen:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-vine:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-code-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-movie-o:before,.fa-file-video-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-sound-o:before,.fa-file-audio-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-zip-o:before,.fa-file-archive-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-photo-o:before,.fa-file-picture-o:before,.fa-file-image-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-powerpoint-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-excel-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-word-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-pdf-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-database:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-soundcloud:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-deviantart:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-spotify:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tree:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cab:before,.fa-taxi:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-automobile:before,.fa-car:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-recycle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-steam-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-steam:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-behance-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-behance:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cubes:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cube:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-spoon:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-paw:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-child:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-building:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-fax:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-language:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-joomla:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-drupal:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pied-piper-alt:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pied-piper:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-digg:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-delicious:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-stumbleupon:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-stumbleupon-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-reddit-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-reddit:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-google:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-yahoo:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-mortar-board:before,.fa-graduation-cap:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-institution:before,.fa-bank:before,.fa-university:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-openid:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-wordpress:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-envelope-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-slack:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-space-shuttle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-plus-square-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-turkish-lira:before,.fa-try:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-vimeo-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-wheelchair:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-dot-circle-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-toggle-left:before,.fa-caret-square-o-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-circle-o-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-circle-o-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-stack-exchange:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pagelines:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-renren:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-weibo:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-vk:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bug:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-archive:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-moon-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sun-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-gittip:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-male:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-female:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-trello:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-foursquare:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-skype:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-dribbble:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-linux:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-android:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-windows:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-apple:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-long-arrow-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-long-arrow-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-long-arrow-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-long-arrow-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tumblr-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tumblr:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bitbucket-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bitbucket:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-adn:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-flickr:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-instagram:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-stack-overflow:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-dropbox:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-youtube-play:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-xing-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-xing:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-youtube:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-youtube-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-thumbs-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-thumbs-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sort-numeric-desc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sort-numeric-asc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sort-amount-desc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sort-amount-asc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sort-alpha-desc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sort-alpha-asc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-text:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bitcoin:before,.fa-btc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-won:before,.fa-krw:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ruble:before,.fa-rouble:before,.fa-rub:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cny:before,.fa-rmb:before,.fa-yen:before,.fa-jpy:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-rupee:before,.fa-inr:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-dollar:before,.fa-usd:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-gbp:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-euro:before,.fa-eur:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-toggle-right:before,.fa-caret-square-o-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-toggle-up:before,.fa-caret-square-o-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-toggle-down:before,.fa-caret-square-o-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-compass:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-share-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-external-link-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pencil-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-check-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-level-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-level-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-minus-square-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-minus-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ticket:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-play-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-rss-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ellipsis-v:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ellipsis-h:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bullseye:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-unlock-alt:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-anchor:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-css3:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-html5:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chevron-circle-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chevron-circle-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chevron-circle-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chevron-circle-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-maxcdn:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-rocket:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-fire-extinguisher:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-calendar-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-shield:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-microphone-slash:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-microphone:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-puzzle-piece:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-eraser:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-subscript:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-superscript:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-exclamation:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-info:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-question:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-unlink:before,.fa-chain-broken:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-code-fork:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-crop:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-location-arrow:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-star-half-empty:before,.fa-star-half-full:before,.fa-star-half-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-mail-reply-all:before,.fa-reply-all:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-code:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-terminal:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-flag-checkered:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-flag-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-keyboard-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-gamepad:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-meh-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-frown-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-smile-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-folder-open-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-folder-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-github-alt:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-mail-reply:before,.fa-reply:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-spinner:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-quote-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-quote-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-circle-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-mobile-phone:before,.fa-mobile:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tablet:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-laptop:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-desktop:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angle-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angle-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angle-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angle-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angle-double-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angle-double-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angle-double-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-angle-double-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-plus-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-h-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-beer:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-fighter-jet:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-medkit:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ambulance:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-hospital-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-building-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-text-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cutlery:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-coffee:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bell-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-suitcase:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-stethoscope:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-user-md:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cloud-upload:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cloud-download:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-exchange:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-lightbulb-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-paste:before,.fa-clipboard:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-umbrella:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sitemap:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-flash:before,.fa-bolt:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-comments-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-comment-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-dashboard:before,.fa-tachometer:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-legal:before,.fa-gavel:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-rotate-left:before,.fa-undo:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-linkedin:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-envelope:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sort-up:before,.fa-sort-asc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sort-down:before,.fa-sort-desc:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-unsorted:before,.fa-sort:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-columns:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-caret-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-caret-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-caret-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-caret-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-money:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-google-plus:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-google-plus-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pinterest-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pinterest:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-truck:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-magic:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-table:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-underline:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-strikethrough:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-list-ol:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-list-ul:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-navicon:before,.fa-reorder:before,.fa-bars:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-save:before,.fa-floppy-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-paperclip:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-copy:before,.fa-files-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cut:before,.fa-scissors:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-flask:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-cloud:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chain:before,.fa-link:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-group:before,.fa-users:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrows-alt:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-briefcase:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-filter:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tasks:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-wrench:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-globe:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-circle-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-circle-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-circle-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-circle-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-hand-o-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-hand-o-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-hand-o-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-hand-o-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-certificate:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bell:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bullhorn:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-hdd-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-rss:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-credit-card:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-unlock:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-github:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-facebook:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-twitter:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-phone-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bookmark-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-square-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-phone:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-lemon-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-upload:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-github-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-trophy:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sign-in:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-external-link:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-thumb-tack:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-linkedin-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-sign-out:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-heart-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-star-half:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-thumbs-o-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-thumbs-o-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-comments:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-gears:before,.fa-cogs:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-key:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-camera-retro:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-facebook-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-twitter-square:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bar-chart-o:before,.fa-bar-chart:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrows-h:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrows-v:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-folder-open:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-folder:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-shopping-cart:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-retweet:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chevron-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chevron-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-magnet:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-comment:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-random:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-calendar:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-plane:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-warning:before,.fa-exclamation-triangle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-eye-slash:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-eye:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-fire:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-leaf:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-gift:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-exclamation-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-asterisk:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-minus:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-plus:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-compress:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-expand:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-mail-forward:before,.fa-share:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ban:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-check-circle-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-times-circle-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-crosshairs:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-info-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-question-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-check-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-times-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-minus-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-plus-circle:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chevron-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-chevron-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-eject:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-step-forward:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-fast-forward:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-forward:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-stop:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pause:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-play:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-backward:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-fast-backward:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-step-backward:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrows:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-check-square-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-share-square-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-edit:before,.fa-pencil-square-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tint:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-adjust:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-map-marker:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-pencil:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-photo:before,.fa-image:before,.fa-picture-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-video-camera:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-indent:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-dedent:before,.fa-outdent:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-list:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-align-justify:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-align-right:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-align-center:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-align-left:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-text-width:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-text-height:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-italic:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bold:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-font:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-camera:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-print:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-bookmark:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-book:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tags:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-tag:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-barcode:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-qrcode:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-volume-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-volume-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-volume-off:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-headphones:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-flag:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-lock:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-list-alt:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-refresh:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-rotate-right:before,.fa-repeat:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-play-circle-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-inbox:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-circle-o-up:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-arrow-circle-o-down:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-download:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-road:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-clock-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-file-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-home:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-trash-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-gear:before,.fa-cog:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-signal:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-power-off:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-search-minus:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-search-plus:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-remove:before,.fa-close:before,.fa-times:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-check:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-th-list:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-th:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-th-large:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-film:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-user:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-star-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-star:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-heart:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-envelope-o:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-search:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-music:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-glass:before",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-inverse",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-stack-2x",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-stack-1x",
+        "declarations": 1
+      },
+      {
+        "selector": ":root .fa-rotate-90,:root .fa-rotate-180,:root .fa-rotate-270,:root .fa-flip-horizontal,:root .fa-flip-vertical",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa.pull-right",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa.pull-left",
+        "declarations": 1
+      },
+      {
+        "selector": ".pull-left",
+        "declarations": 1
+      },
+      {
+        "selector": ".pull-right",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-li.fa-lg",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-ul>li",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-5x",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-4x",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-3x",
+        "declarations": 1
+      },
+      {
+        "selector": ".fa-2x",
+        "declarations": 1
+      }
+    ]
   },
   "selectors": {
     "total": 586,

--- a/test/results/gridio-national-light.json
+++ b/test/results/gridio-national-light.json
@@ -9,7 +9,8 @@
       "graph": [],
       "max": 0,
       "average": 0
-    }
+    },
+    "selectorByRuleSizes": []
   },
   "selectors": {
     "total": 0,

--- a/test/results/gridio.json
+++ b/test/results/gridio.json
@@ -24,7 +24,65 @@
       ],
       "max": 10,
       "average": 4.285714285714286
-    }
+    },
+    "selectorByRuleSizes": [
+      {
+        "selector": ".odometer.odometer-auto-theme.odometer-animating-down.odometer-animating .odometer-ribbon-inner, .odometer.odometer-theme-default.odometer-animating-down.odometer-animating .odometer-ribbon-inner",
+        "declarations": 10
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme .odometer-digit .odometer-digit-inner, .odometer.odometer-theme-default .odometer-digit .odometer-digit-inner",
+        "declarations": 8
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme .odometer-digit .odometer-digit-spacer, .odometer.odometer-theme-default .odometer-digit .odometer-digit-spacer",
+        "declarations": 6
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme .odometer-digit, .odometer.odometer-theme-default .odometer-digit",
+        "declarations": 6
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme, .odometer.odometer-theme-default",
+        "declarations": 6
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme.odometer-animating-down .odometer-ribbon-inner, .odometer.odometer-theme-default.odometer-animating-down .odometer-ribbon-inner",
+        "declarations": 5
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme.odometer-animating-up.odometer-animating .odometer-ribbon-inner, .odometer.odometer-theme-default.odometer-animating-up.odometer-animating .odometer-ribbon-inner",
+        "declarations": 5
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme.odometer-animating-up .odometer-ribbon-inner, .odometer.odometer-theme-default.odometer-animating-up .odometer-ribbon-inner",
+        "declarations": 5
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme, .odometer.odometer-theme-default",
+        "declarations": 2
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme .odometer-digit .odometer-value, .odometer.odometer-theme-default .odometer-digit .odometer-value",
+        "declarations": 2
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme .odometer-digit .odometer-ribbon-inner, .odometer.odometer-theme-default .odometer-digit .odometer-ribbon-inner",
+        "declarations": 2
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme .odometer-value, .odometer.odometer-theme-default .odometer-value",
+        "declarations": 1
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme .odometer-digit .odometer-value.odometer-last-value, .odometer.odometer-theme-default .odometer-digit .odometer-value.odometer-last-value",
+        "declarations": 1
+      },
+      {
+        "selector": ".odometer.odometer-auto-theme .odometer-digit .odometer-ribbon, .odometer.odometer-theme-default .odometer-digit .odometer-ribbon",
+        "declarations": 1
+      }
+    ]
   },
   "selectors": {
     "total": 28,

--- a/test/results/small.json
+++ b/test/results/small.json
@@ -22,7 +22,57 @@
       ],
       "max": 4,
       "average": 1.8333333333333333
-    }
+    },
+    "selectorByRuleSizes": [
+      {
+        "selector": "100%",
+        "declarations": 4
+      },
+      {
+        "selector": "0%",
+        "declarations": 4
+      },
+      {
+        "selector": ".sm-tomato",
+        "declarations": 3
+      },
+      {
+        "selector": ".box",
+        "declarations": 2
+      },
+      {
+        "selector": ".sm-tomato:first-child:last-child",
+        "declarations": 2
+      },
+      {
+        "selector": ".georgia",
+        "declarations": 1
+      },
+      {
+        "selector": "header",
+        "declarations": 1
+      },
+      {
+        "selector": ".box:last-child",
+        "declarations": 1
+      },
+      {
+        "selector": ".box:first-child",
+        "declarations": 1
+      },
+      {
+        "selector": ".sm-tomato::after",
+        "declarations": 1
+      },
+      {
+        "selector": ".red",
+        "declarations": 1
+      },
+      {
+        "selector": ".red, #foo",
+        "declarations": 1
+      }
+    ]
   },
   "selectors": {
     "total": 13,
@@ -122,7 +172,13 @@
             ],
             "max": 3,
             "average": 3
-          }
+          },
+          "selectorByRuleSizes": [
+            {
+              "selector": ".sm-tomato",
+              "declarations": 3
+            }
+          ]
         },
         "selectors": {
           "total": 1,

--- a/test/test.js
+++ b/test/test.js
@@ -53,6 +53,23 @@ describe('css-statistics', function () {
     it('should return a rule size graph', function () {
       assert.deepEqual(stats.rules.size.graph, [ 1, 1, 3, 1, 2, 2, 1, 1, 4, 4, 1, 1 ])
     })
+
+    it('should return a selectorByRuleSizes array', function () {
+      assert.deepEqual(stats.rules.selectorByRuleSizes, [
+        { selector: '100%', declarations: 4 },
+        { selector: '0%', declarations: 4 },
+        { selector: '.sm-tomato', declarations: 3 },
+        { selector: '.box', declarations: 2 },
+        { selector: '.sm-tomato:first-child:last-child', declarations: 2 },
+        { selector: '.georgia', declarations: 1 },
+        { selector: 'header', declarations: 1 },
+        { selector: '.box:last-child', declarations: 1 },
+        { selector: '.box:first-child', declarations: 1 },
+        { selector: '.sm-tomato::after', declarations: 1 },
+        { selector: '.red', declarations: 1 },
+        { selector: '.red, #foo', declarations: 1 }
+      ])
+    })
   })
 
   describe('selectors', function () {


### PR DESCRIPTION
In order to allow user to detect what rules may be too big, and correct them, we return an array of objects containing `selector:string` and `declarations:number` keys.

related to https://github.com/cssstats/core/issues/61