### PR TITLE
Correct Travis build badge url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# cssstats [![Build Status](https://travis-ci.org/cssstats/cssstats-core.svg?branch=master)](https://travis-ci.org/cssstats/cssstats-core)
+# cssstats [![Build Status](https://travis-ci.org/cssstats/core.svg?branch=master)](https://travis-ci.org/cssstats/core)
 
 Parses stylesheets and returns an object with statistics.
 This is the core module used in [cssstats.com](http://cssstats.com)


### PR DESCRIPTION
By pointing it to the correct repo name.